### PR TITLE
v0.2.0: No zombies, node dedup, auto-updates

### DIFF
--- a/client.js
+++ b/client.js
@@ -5,24 +5,71 @@
  * Runs on each node (Mac Mini, laptop, server).
  * Checks in with the coordination server, picks up jobs, reports results.
  * 
+ * Safety-first design:
+ * - All jobs run with hard timeouts (no zombies)
+ * - Node ID persisted to disk (no duplicate registrations)
+ * - Auto-updates from git (no manual SSH needed)
+ * - Child processes tracked and killed on timeout
+ * - Graceful shutdown on SIGINT/SIGTERM
+ * 
  * Usage:
- *   IC_MESH_SERVER=https://moilol.com:8333 \
- *   IC_NODE_NAME=hilo-coffee-shop \
+ *   IC_MESH_SERVER=https://moilol.com/mesh \
+ *   IC_NODE_NAME=my-node \
  *   IC_NODE_OWNER=drake \
  *   node client.js
  */
 
 const os = require('os');
-const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const { execSync, spawn } = require('child_process');
+const crypto = require('crypto');
+
+// ===== Configuration =====
 
 const MESH_SERVER = process.env.IC_MESH_SERVER || 'http://localhost:8333';
 const NODE_NAME = process.env.IC_NODE_NAME || os.hostname();
 const NODE_OWNER = process.env.IC_NODE_OWNER || os.userInfo().username;
 const NODE_REGION = process.env.IC_NODE_REGION || 'unknown';
-const CHECKIN_INTERVAL = 60000; // 60 seconds
-const JOB_POLL_INTERVAL = 10000; // 10 seconds
+const CHECKIN_INTERVAL = 60_000;        // 60s
+const JOB_POLL_INTERVAL = 10_000;       // 10s
+const UPDATE_CHECK_INTERVAL = 300_000;  // 5 min
+const NODE_ID_FILE = path.join(__dirname, '.node-id');
+const VERSION_FILE = path.join(__dirname, '.version');
 
-let nodeId = null;
+// Job timeout defaults (ms) — can be overridden per-job via payload.timeout
+const JOB_TIMEOUTS = {
+  ping: 5_000,
+  inference: 300_000,    // 5 min
+  transcribe: 600_000,   // 10 min
+  generate: 900_000,     // 15 min (SD can be slow)
+  default: 300_000       // 5 min fallback
+};
+
+let nodeId = loadNodeId();
+let currentJob = null;         // Track active job for cleanup
+let activeChildProcess = null; // Track child process for kill
+let shuttingDown = false;
+
+// ===== Node ID Persistence =====
+
+function loadNodeId() {
+  try {
+    const id = fs.readFileSync(NODE_ID_FILE, 'utf8').trim();
+    if (id && id.length >= 8) return id;
+  } catch {}
+  return null;
+}
+
+function saveNodeId(id) {
+  try { fs.writeFileSync(NODE_ID_FILE, id); } catch {}
+}
+
+function getLocalVersion() {
+  try {
+    return execSync('git rev-parse --short HEAD', { cwd: __dirname, encoding: 'utf8', timeout: 5000 }).trim();
+  } catch { return 'unknown'; }
+}
 
 // ===== System Info =====
 
@@ -32,7 +79,7 @@ function getSystemInfo() {
   const freeMem = Math.round(os.freemem() / 1024 / 1024);
   const loadAvg = os.loadavg()[0];
   const cpuIdle = Math.max(0, Math.round((1 - loadAvg / cpus.length) * 100));
-  
+
   return {
     cpuCores: cpus.length,
     cpuModel: cpus[0]?.model || 'unknown',
@@ -40,71 +87,64 @@ function getSystemInfo() {
     ramFreeMB: freeMem,
     cpuIdle,
     diskFreeGB: getDiskFree(),
-    gpuVRAM: 0 // TODO: detect GPU
+    gpuVRAM: 0
   };
 }
 
 function getDiskFree() {
   try {
     if (process.platform === 'darwin') {
-      const out = execSync("df -g / | tail -1 | awk '{print $4}'", { encoding: 'utf8' });
+      const out = execSync("df -g / | tail -1 | awk '{print $4}'", { encoding: 'utf8', timeout: 5000 });
       return parseInt(out) || 0;
     }
-    const out = execSync("df -BG / | tail -1 | awk '{print $4}'", { encoding: 'utf8' });
+    const out = execSync("df -BG / | tail -1 | awk '{print $4}'", { encoding: 'utf8', timeout: 5000 });
     return parseInt(out) || 0;
   } catch { return 0; }
 }
 
 function getCapabilities() {
   const caps = [];
-  
-  // Check for Ollama
-  try { execSync('which ollama', { encoding: 'utf8' }); caps.push('ollama'); } catch {}
-  
-  // Check for Whisper
-  try { execSync('which whisper', { encoding: 'utf8' }); caps.push('whisper'); } catch {}
-  
-  // Check for ffmpeg
-  try { execSync('which ffmpeg', { encoding: 'utf8' }); caps.push('ffmpeg'); } catch {}
-  
-  // Check for GPU (nvidia)
-  try { execSync('which nvidia-smi', { encoding: 'utf8' }); caps.push('gpu-nvidia'); } catch {}
-  
-  // Check for Metal (Apple Silicon)
+  const check = (cmd) => { try { execSync(cmd, { encoding: 'utf8', timeout: 3000 }); return true; } catch { return false; } };
+  const httpCheck = (url) => {
+    try {
+      return execSync(`curl -s -o /dev/null -w "%{http_code}" "${url}" --max-time 2`, { encoding: 'utf8', timeout: 5000 }).trim() === '200';
+    } catch { return false; }
+  };
+
+  if (check('which ollama')) caps.push('ollama');
+  if (check('which whisper')) caps.push('whisper');
+  if (check('which ffmpeg')) caps.push('ffmpeg');
+  if (check('which nvidia-smi')) caps.push('gpu-nvidia');
+
   try {
-    const arch = execSync('uname -m', { encoding: 'utf8' }).trim();
+    const arch = execSync('uname -m', { encoding: 'utf8', timeout: 3000 }).trim();
     if (arch === 'arm64' && process.platform === 'darwin') caps.push('gpu-metal');
   } catch {}
 
-  // Check for Stable Diffusion (A1111 / ComfyUI)
-  try {
-    const resp = execSync('curl -s -o /dev/null -w "%{http_code}" http://localhost:7860/sdapi/v1/sd-models --max-time 2', { encoding: 'utf8' }).trim();
-    if (resp === '200') caps.push('stable-diffusion');
-  } catch {}
+  if (httpCheck('http://localhost:7860/sdapi/v1/sd-models')) caps.push('stable-diffusion');
+  if (httpCheck('http://localhost:8188/system_stats')) caps.push('comfyui');
 
-  // Check for ComfyUI
-  try {
-    const resp = execSync('curl -s -o /dev/null -w "%{http_code}" http://localhost:8188/system_stats --max-time 2', { encoding: 'utf8' }).trim();
-    if (resp === '200') caps.push('comfyui');
-  } catch {}
-  
   return caps;
 }
 
 function getOllamaModels() {
   try {
-    const out = execSync('ollama list 2>/dev/null', { encoding: 'utf8' });
+    const out = execSync('ollama list 2>/dev/null', { encoding: 'utf8', timeout: 10000 });
     return out.split('\n').slice(1).filter(Boolean).map(line => line.split(/\s+/)[0]).filter(Boolean);
   } catch { return []; }
 }
 
 // ===== Network Communication =====
 
-async function meshFetch(path, options = {}) {
-  const url = `${MESH_SERVER}${path}`;
+async function meshFetch(urlPath, options = {}) {
+  const url = `${MESH_SERVER}${urlPath}`;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 15000);
+
   try {
     const resp = await fetch(url, {
       ...options,
+      signal: controller.signal,
       headers: {
         'Content-Type': 'application/json',
         'X-Node-Id': nodeId || '',
@@ -113,126 +153,149 @@ async function meshFetch(path, options = {}) {
     });
     return await resp.json();
   } catch (e) {
-    console.error(`  ✗ Mesh server unreachable: ${e.message}`);
+    if (e.name !== 'AbortError') {
+      console.error(`  ✗ Mesh server unreachable: ${e.message}`);
+    }
     return null;
+  } finally {
+    clearTimeout(timeout);
   }
 }
 
-// ===== Core Loop =====
-
-async function checkin() {
-  const sysInfo = getSystemInfo();
-  const capabilities = getCapabilities();
-  const models = getOllamaModels();
-  
-  const data = {
-    nodeId,
-    name: NODE_NAME,
-    owner: NODE_OWNER,
-    region: NODE_REGION,
-    capabilities,
-    models,
-    ...sysInfo
-  };
-  
-  const result = await meshFetch('/nodes/register', {
-    method: 'POST',
-    body: JSON.stringify(data)
-  });
-  
-  if (result?.ok) {
-    if (!nodeId) {
-      nodeId = result.node.nodeId;
-      console.log(`◉ Registered as node: ${nodeId}`);
-      console.log(`  Name: ${NODE_NAME}`);
-      console.log(`  Capabilities: ${capabilities.join(', ') || 'none detected'}`);
-      console.log(`  Models: ${models.join(', ') || 'none'}`);
-      console.log(`  RAM: ${sysInfo.ramMB}MB (${sysInfo.ramFreeMB}MB free)`);
-      console.log(`  CPU: ${sysInfo.cpuCores} cores (${sysInfo.cpuIdle}% idle)`);
+async function meshFetchRetry(urlPath, options = {}, retries = 3) {
+  for (let i = 1; i <= retries; i++) {
+    const result = await meshFetch(urlPath, options);
+    if (result) return result;
+    if (i < retries) {
+      console.log(`  ⟳ Retry ${i}/${retries} in ${i * 2}s...`);
+      await sleep(i * 2000);
     }
   }
+  return null;
 }
 
-async function pollJobs() {
-  if (!nodeId) return;
-  
-  const result = await meshFetch(`/jobs/available?nodeId=${nodeId}`);
-  if (!result?.jobs?.length) return;
-  
-  for (const job of result.jobs) {
-    console.log(`◉ Job available: ${job.type} (${job.jobId})`);
-    
-    // Claim it
-    const claimed = await meshFetch(`/jobs/${job.jobId}/claim`, {
-      method: 'POST',
-      body: JSON.stringify({ nodeId })
+function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
+
+// ===== Job Execution with Timeout =====
+
+function getJobTimeout(job) {
+  // Payload can override, but cap at 30 min
+  if (job.payload?.timeout) return Math.min(job.payload.timeout * 1000, 1_800_000);
+  return JOB_TIMEOUTS[job.type] || JOB_TIMEOUTS.default;
+}
+
+/**
+ * Run a shell command with a hard timeout. Returns stdout.
+ * Kills the process tree on timeout — no zombies.
+ */
+function execWithTimeout(cmd, timeoutMs, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn('sh', ['-c', cmd], {
+      encoding: 'utf8',
+      ...options
     });
-    
-    if (!claimed?.ok) {
-      console.log(`  ✗ Failed to claim (someone else got it)`);
-      continue;
-    }
-    
-    console.log(`  ✓ Claimed. Executing...`);
-    
-    // Execute the job
-    try {
-      const result = await executeJob(job);
-      
-      // Retry completion POST up to 3 times
-      let reported = false;
-      for (let attempt = 1; attempt <= 3; attempt++) {
-        const resp = await meshFetch(`/jobs/${job.jobId}/complete`, {
-          method: 'POST',
-          body: JSON.stringify({ nodeId, data: result })
-        });
-        if (resp?.ok) { reported = true; break; }
-        console.log(`  ⟳ Completion report attempt ${attempt}/3 failed, retrying in ${attempt * 2}s...`);
-        await new Promise(r => setTimeout(r, attempt * 2000));
+
+    activeChildProcess = child;
+    let stdout = '';
+    let stderr = '';
+    let killed = false;
+
+    child.stdout?.on('data', d => { stdout += d; });
+    child.stderr?.on('data', d => { stderr += d; });
+
+    const timer = setTimeout(() => {
+      killed = true;
+      console.log(`  ⏰ Job timeout (${Math.round(timeoutMs/1000)}s) — killing process ${child.pid}`);
+      try {
+        // Kill process group to catch any children
+        process.kill(-child.pid, 'SIGKILL');
+      } catch {
+        try { child.kill('SIGKILL'); } catch {}
       }
-      
-      console.log(`  ✓ Completed: ${job.type}${reported ? '' : ' (result not reported to server)'}`);
-    } catch (e) {
-      console.error(`  ✗ Job failed: ${e.message}`);
+    }, timeoutMs);
+
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      activeChildProcess = null;
+      if (killed) {
+        reject(new Error(`Command timed out after ${Math.round(timeoutMs/1000)}s`));
+      } else if (code !== 0) {
+        reject(new Error(`Command exited with code ${code}: ${stderr.slice(0, 500)}`));
+      } else {
+        resolve(stdout);
+      }
+    });
+
+    child.on('error', (e) => {
+      clearTimeout(timer);
+      activeChildProcess = null;
+      reject(e);
+    });
+  });
+}
+
+async function executeJobSafe(job) {
+  const timeoutMs = getJobTimeout(job);
+  currentJob = job;
+
+  try {
+    // Wrap the entire job execution in a timeout
+    const result = await Promise.race([
+      executeJob(job),
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error(`Job master timeout (${Math.round(timeoutMs/1000)}s)`)), timeoutMs + 5000)
+      )
+    ]);
+    return result;
+  } finally {
+    currentJob = null;
+    // Ensure no child processes linger
+    if (activeChildProcess) {
+      try { activeChildProcess.kill('SIGKILL'); } catch {}
+      activeChildProcess = null;
     }
   }
 }
+
+// ===== Job Handlers =====
 
 async function executeJob(job) {
   switch (job.type) {
-    case 'inference':
-      return await runInference(job.payload);
-    case 'transcribe':
-      return await runTranscribe(job.payload);
-    case 'generate':
-      return await runGenerate(job.payload);
-    case 'ping':
-      return { pong: true, node: NODE_NAME, time: Date.now() };
-    default:
-      throw new Error(`Unknown job type: ${job.type}`);
+    case 'inference': return await runInference(job.payload, getJobTimeout(job));
+    case 'transcribe': return await runTranscribe(job.payload, getJobTimeout(job));
+    case 'generate': return await runGenerate(job.payload, getJobTimeout(job));
+    case 'ping': return { pong: true, node: NODE_NAME, time: Date.now(), version: getLocalVersion() };
+    default: throw new Error(`Unknown job type: ${job.type}`);
   }
 }
 
-async function runInference(payload) {
+async function runInference(payload, timeoutMs) {
   const model = payload.model || 'llama3.1:8b';
   const prompt = payload.prompt || '';
-  
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
   try {
     const resp = await fetch('http://localhost:11434/api/generate', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ model, prompt, stream: false })
+      body: JSON.stringify({ model, prompt, stream: false }),
+      signal: controller.signal
     });
     const data = await resp.json();
     return { response: data.response, model, tokens: data.eval_count || 0 };
   } catch (e) {
+    if (e.name === 'AbortError') throw new Error(`Inference timed out (${Math.round(timeoutMs/1000)}s)`);
     throw new Error(`Ollama inference failed: ${e.message}`);
+  } finally {
+    clearTimeout(timer);
   }
 }
 
-async function runGenerate(payload) {
+async function runGenerate(payload, timeoutMs) {
   const SD_URL = process.env.IC_SD_URL || 'http://localhost:7860';
-  
+
   const params = {
     prompt: payload.prompt || '',
     negative_prompt: payload.negative_prompt || '',
@@ -246,14 +309,16 @@ async function runGenerate(payload) {
     n_iter: 1
   };
 
-  // Optionally set the model
   if (payload.model) {
     console.log(`  ◉ Switching to model: ${payload.model}`);
     try {
+      const controller = new AbortController();
+      setTimeout(() => controller.abort(), 30000);
       await fetch(`${SD_URL}/sdapi/v1/options`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ sd_model_checkpoint: payload.model })
+        body: JSON.stringify({ sd_model_checkpoint: payload.model }),
+        signal: controller.signal
       });
     } catch (e) {
       console.log(`  ⚠ Model switch failed: ${e.message} (using current model)`);
@@ -262,135 +327,300 @@ async function runGenerate(payload) {
 
   console.log(`  ◉ Generating image: "${params.prompt.slice(0, 80)}..." (${params.width}x${params.height}, ${params.steps} steps)`);
 
-  const resp = await fetch(`${SD_URL}/sdapi/v1/txt2img`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(params)
-  });
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
 
-  if (!resp.ok) {
-    const err = await resp.text();
-    throw new Error(`SD API error (${resp.status}): ${err.slice(0, 200)}`);
-  }
-
-  const data = await resp.json();
-
-  if (!data.images || !data.images.length) {
-    throw new Error('No images returned from SD API');
-  }
-
-  // Upload the image to the mesh hub for retrieval
-  const imgBuffer = Buffer.from(data.images[0], 'base64');
-  const filename = `gen-${Date.now()}.png`;
-  
-  // Try to upload to hub
   try {
-    const boundary = '----ICMesh' + Date.now();
-    const header = Buffer.from(
-      `--${boundary}\r\nContent-Disposition: form-data; name="file"; filename="${filename}"\r\nContent-Type: image/png\r\n\r\n`
-    );
-    const footer = Buffer.from(`\r\n--${boundary}--\r\n`);
-    const body = Buffer.concat([header, imgBuffer, footer]);
-    
-    const uploadResp = await fetch(`${MESH_SERVER}/upload`, {
+    const resp = await fetch(`${SD_URL}/sdapi/v1/txt2img`, {
       method: 'POST',
-      headers: { 'Content-Type': `multipart/form-data; boundary=${boundary}` },
-      body
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(params),
+      signal: controller.signal
     });
-    const uploadResult = await uploadResp.json();
-    
-    if (uploadResult.url) {
-      return {
-        url: uploadResult.url,
-        width: params.width,
-        height: params.height,
-        prompt: params.prompt,
-        steps: params.steps,
-        seed: data.parameters?.seed || params.seed,
-        sizeBytes: imgBuffer.length
-      };
-    }
-  } catch (e) {
-    console.log(`  ⚠ Hub upload failed: ${e.message}, returning base64`);
-  }
 
-  // Fallback: return base64 (large but works)
-  return {
-    image_base64: data.images[0],
-    width: params.width,
-    height: params.height,
-    prompt: params.prompt,
-    steps: params.steps,
-    seed: data.parameters?.seed || params.seed,
-    sizeBytes: imgBuffer.length
-  };
+    if (!resp.ok) {
+      const err = await resp.text();
+      throw new Error(`SD API error (${resp.status}): ${err.slice(0, 200)}`);
+    }
+
+    const data = await resp.json();
+    if (!data.images || !data.images.length) throw new Error('No images returned from SD API');
+
+    const imgBuffer = Buffer.from(data.images[0], 'base64');
+    const filename = `gen-${Date.now()}.png`;
+
+    // Try hub upload
+    try {
+      const boundary = '----ICMesh' + Date.now();
+      const header = Buffer.from(
+        `--${boundary}\r\nContent-Disposition: form-data; name="file"; filename="${filename}"\r\nContent-Type: image/png\r\n\r\n`
+      );
+      const footer = Buffer.from(`\r\n--${boundary}--\r\n`);
+      const body = Buffer.concat([header, imgBuffer, footer]);
+
+      const uploadResp = await fetch(`${MESH_SERVER}/upload`, {
+        method: 'POST',
+        headers: { 'Content-Type': `multipart/form-data; boundary=${boundary}` },
+        body
+      });
+      const uploadResult = await uploadResp.json();
+
+      if (uploadResult.url) {
+        return {
+          url: uploadResult.url, width: params.width, height: params.height,
+          prompt: params.prompt, steps: params.steps,
+          seed: data.parameters?.seed || params.seed, sizeBytes: imgBuffer.length
+        };
+      }
+    } catch (e) {
+      console.log(`  ⚠ Hub upload failed: ${e.message}, returning base64`);
+    }
+
+    return {
+      image_base64: data.images[0], width: params.width, height: params.height,
+      prompt: params.prompt, steps: params.steps,
+      seed: data.parameters?.seed || params.seed, sizeBytes: imgBuffer.length
+    };
+  } catch (e) {
+    if (e.name === 'AbortError') throw new Error(`SD generation timed out (${Math.round(timeoutMs/1000)}s)`);
+    throw e;
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
-async function runTranscribe(payload) {
-  const { execSync } = require('child_process');
-  const fs = require('fs');
-  const os = require('os');
-  const path = require('path');
-
+async function runTranscribe(payload, timeoutMs) {
   const url = payload.url;
   if (!url) throw new Error('No audio URL provided');
 
-  // Download to temp file
   const tmpDir = path.join(os.tmpdir(), 'ic-mesh-jobs');
   if (!fs.existsSync(tmpDir)) fs.mkdirSync(tmpDir, { recursive: true });
   const ext = path.extname(new URL(url).pathname) || '.wav';
   const tmpFile = path.join(tmpDir, `transcribe-${Date.now()}${ext}`);
-
-  console.log(`  ↓ Downloading: ${url}`);
-  execSync(`curl -sL -o "${tmpFile}" "${url}"`, { timeout: 120000 });
-
-  // Run whisper
-  const model = payload.model || 'base';
-  const language = payload.language || 'en';
-  console.log(`  ◉ Transcribing with whisper (model: ${model})...`);
-
   const outDir = path.join(tmpDir, `out-${Date.now()}`);
   fs.mkdirSync(outDir, { recursive: true });
 
-  execSync(`whisper "${tmpFile}" --model ${model} --language ${language} --output_dir "${outDir}" --output_format txt`, {
-    timeout: 600000, // 10 min max
-    encoding: 'utf8'
+  try {
+    console.log(`  ↓ Downloading: ${url}`);
+    await execWithTimeout(`curl -sL -o "${tmpFile}" "${url}"`, Math.min(timeoutMs, 120000));
+
+    const model = payload.model || 'base';
+    const language = payload.language || 'en';
+    console.log(`  ◉ Transcribing with whisper (model: ${model})...`);
+
+    await execWithTimeout(
+      `whisper "${tmpFile}" --model ${model} --language ${language} --output_dir "${outDir}" --output_format txt`,
+      timeoutMs
+    );
+
+    const txtFiles = fs.readdirSync(outDir).filter(f => f.endsWith('.txt'));
+    const transcript = txtFiles.length
+      ? fs.readFileSync(path.join(outDir, txtFiles[0]), 'utf8').trim()
+      : '(no output)';
+
+    return { transcript, model, language, chars: transcript.length };
+  } finally {
+    // Always clean up temp files
+    try { fs.unlinkSync(tmpFile); } catch {}
+    try { fs.rmSync(outDir, { recursive: true }); } catch {}
+  }
+}
+
+// ===== Auto-Update =====
+
+async function checkForUpdates() {
+  if (shuttingDown) return;
+
+  try {
+    // Fetch latest from remote
+    execSync('git fetch origin main --quiet 2>/dev/null', { cwd: __dirname, timeout: 15000 });
+
+    const local = execSync('git rev-parse HEAD', { cwd: __dirname, encoding: 'utf8', timeout: 5000 }).trim();
+    const remote = execSync('git rev-parse origin/main', { cwd: __dirname, encoding: 'utf8', timeout: 5000 }).trim();
+
+    if (local === remote) return; // Up to date
+
+    console.log(`\n◉ Update available: ${local.slice(0,7)} → ${remote.slice(0,7)}`);
+
+    // Don't update if we're running a job
+    if (currentJob) {
+      console.log('  ⏳ Job in progress — will update after completion');
+      // Recheck in 30s
+      setTimeout(checkForUpdates, 30000);
+      return;
+    }
+
+    console.log('  ↓ Pulling update...');
+    execSync('git pull origin main --quiet', { cwd: __dirname, timeout: 30000 });
+    console.log('  ✓ Updated. Restarting...\n');
+
+    // Restart: re-exec ourselves with the same args + env
+    const args = process.argv.slice(1);
+    const child = spawn(process.argv[0], args, {
+      cwd: process.cwd(),
+      env: process.env,
+      stdio: 'inherit',
+      detached: true
+    });
+    child.unref();
+    process.exit(0);
+
+  } catch (e) {
+    // Non-fatal — just skip this update check
+    if (e.message && !e.message.includes('not a git repository')) {
+      console.error(`  ✗ Update check failed: ${e.message}`);
+    }
+  }
+}
+
+// ===== Core Loop =====
+
+async function checkin() {
+  if (shuttingDown) return;
+
+  const sysInfo = getSystemInfo();
+  const capabilities = getCapabilities();
+  const models = getOllamaModels();
+
+  const data = {
+    nodeId,
+    name: NODE_NAME,
+    owner: NODE_OWNER,
+    region: NODE_REGION,
+    capabilities,
+    models,
+    version: getLocalVersion(),
+    ...sysInfo
+  };
+
+  const result = await meshFetch('/nodes/register', {
+    method: 'POST',
+    body: JSON.stringify(data)
   });
 
-  // Read result
-  const txtFiles = fs.readdirSync(outDir).filter(f => f.endsWith('.txt'));
-  const transcript = txtFiles.length
-    ? fs.readFileSync(path.join(outDir, txtFiles[0]), 'utf8').trim()
-    : '(no output)';
-
-  // Cleanup
-  try { fs.unlinkSync(tmpFile); fs.rmSync(outDir, { recursive: true }); } catch {}
-
-  return { transcript, model, language, chars: transcript.length };
+  if (result?.ok) {
+    if (!nodeId || nodeId !== result.node.nodeId) {
+      nodeId = result.node.nodeId;
+      saveNodeId(nodeId);
+      console.log(`◉ Registered as node: ${nodeId}`);
+      console.log(`  Name: ${NODE_NAME}`);
+      console.log(`  Capabilities: ${capabilities.join(', ') || 'none detected'}`);
+      console.log(`  Models: ${models.join(', ') || 'none'}`);
+      console.log(`  RAM: ${sysInfo.ramMB}MB (${sysInfo.ramFreeMB}MB free)`);
+      console.log(`  CPU: ${sysInfo.cpuCores} cores (${sysInfo.cpuIdle}% idle)`);
+    }
+  }
 }
+
+let jobRunning = false;
+
+async function pollJobs() {
+  if (!nodeId || shuttingDown || jobRunning) return;
+
+  const result = await meshFetch(`/jobs/available?nodeId=${nodeId}`);
+  if (!result?.jobs?.length) return;
+
+  // Only take one job at a time
+  const job = result.jobs[0];
+  console.log(`◉ Job available: ${job.type} (${job.jobId})`);
+
+  const claimed = await meshFetch(`/jobs/${job.jobId}/claim`, {
+    method: 'POST',
+    body: JSON.stringify({ nodeId })
+  });
+
+  if (!claimed?.ok) {
+    console.log(`  ✗ Failed to claim (someone else got it)`);
+    return;
+  }
+
+  console.log(`  ✓ Claimed. Executing (timeout: ${Math.round(getJobTimeout(job)/1000)}s)...`);
+  jobRunning = true;
+
+  try {
+    const result = await executeJobSafe(job);
+
+    const resp = await meshFetchRetry(`/jobs/${job.jobId}/complete`, {
+      method: 'POST',
+      body: JSON.stringify({ nodeId, data: result })
+    });
+
+    console.log(`  ✓ Completed: ${job.type}${resp?.ok ? '' : ' (result not reported to server)'}`);
+  } catch (e) {
+    console.error(`  ✗ Job failed: ${e.message}`);
+
+    // Report failure to server so it can re-queue
+    await meshFetchRetry(`/jobs/${job.jobId}/fail`, {
+      method: 'POST',
+      body: JSON.stringify({ nodeId, error: e.message })
+    });
+  } finally {
+    jobRunning = false;
+  }
+}
+
+// ===== Graceful Shutdown =====
+
+function shutdown(signal) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  console.log(`\n◉ ${signal} received. Shutting down gracefully...`);
+
+  // Kill any active child process
+  if (activeChildProcess) {
+    console.log('  Killing active job process...');
+    try { activeChildProcess.kill('SIGKILL'); } catch {}
+  }
+
+  // Give a moment for cleanup, then exit
+  setTimeout(() => process.exit(0), 1000);
+}
+
+process.on('SIGINT', () => shutdown('SIGINT'));
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('uncaughtException', (e) => {
+  console.error(`\n✗ Uncaught exception: ${e.message}`);
+  console.error(e.stack);
+  // Don't crash — keep running
+});
+process.on('unhandledRejection', (e) => {
+  console.error(`\n✗ Unhandled rejection: ${e}`);
+  // Don't crash — keep running
+});
 
 // ===== Main =====
 
 async function main() {
+  const version = getLocalVersion();
+
   console.log('');
-  console.log('┌──────────────────────────────────┐');
-  console.log('│  ◉ IC MESH — Node Client v0.1.0  │');
-  console.log('└──────────────────────────────────┘');
-  console.log(`  Server: ${MESH_SERVER}`);
-  console.log(`  Node:   ${NODE_NAME}`);
-  console.log(`  Owner:  ${NODE_OWNER}`);
+  console.log('┌──────────────────────────────────────┐');
+  console.log(`│  ◉ IC MESH — Node Client v0.2.0      │`);
+  console.log('└──────────────────────────────────────┘');
+  console.log(`  Server:  ${MESH_SERVER}`);
+  console.log(`  Node:    ${NODE_NAME}`);
+  console.log(`  Owner:   ${NODE_OWNER}`);
+  console.log(`  Version: ${version}`);
+  console.log(`  NodeID:  ${nodeId || '(new — will register)'}`);
   console.log('');
-  
+
   // Initial checkin
   await checkin();
-  
+
   // Periodic checkin
   setInterval(checkin, CHECKIN_INTERVAL);
-  
+
   // Poll for jobs
   setInterval(pollJobs, JOB_POLL_INTERVAL);
-  
-  console.log(`\n◉ Node running. Checking in every ${CHECKIN_INTERVAL/1000}s, polling jobs every ${JOB_POLL_INTERVAL/1000}s`);
+
+  // Check for updates every 5 min
+  setTimeout(checkForUpdates, 30000); // First check after 30s
+  setInterval(checkForUpdates, UPDATE_CHECK_INTERVAL);
+
+  console.log(`\n◉ Node running.`);
+  console.log(`  Check-in: every ${CHECKIN_INTERVAL/1000}s`);
+  console.log(`  Job poll: every ${JOB_POLL_INTERVAL/1000}s`);
+  console.log(`  Updates:  every ${UPDATE_CHECK_INTERVAL/1000}s`);
   console.log('  Press Ctrl+C to leave the mesh.\n');
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "ic-mesh",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ic-mesh",
+      "version": "0.1.0"
+    }
+  }
+}

--- a/server.js
+++ b/server.js
@@ -3,23 +3,26 @@
  * IC Mesh — Coordination Server
  * 
  * The central hub that coordinates the Intelligence Club compute mesh.
- * Runs on our server (157.245.189.193). Nodes check in here.
  * 
- * Components:
- * 1. Node Registry — who's online, what can they do
- * 2. Job Queue — tasks waiting to be claimed
- * 3. Compute Broker — routes jobs to best available node  
- * 4. Ledger — tracks compute credits/debits
+ * Safety features:
+ * - Node deduplication by name+owner (no ghost nodes)
+ * - Job timeout reaper (claimed jobs auto-fail after TTL)
+ * - Failed job tracking and re-queue support
+ * - Version tracking per node (for update awareness)
  * 
  * API:
- *   POST /nodes/register    — node checks in
+ *   POST /nodes/register    — node checks in (deduplicates by name+owner)
  *   GET  /nodes             — list active nodes
  *   POST /jobs              — submit a job
  *   GET  /jobs/available    — get claimable jobs (for nodes)
+ *   GET  /jobs/:id          — get job status/result
  *   POST /jobs/:id/claim    — node claims a job
  *   POST /jobs/:id/complete — node reports job done
+ *   POST /jobs/:id/fail     — node reports job failed
  *   GET  /ledger/:nodeId    — get node's compute balance
- *   GET  /status            — network status
+ *   GET  /status            — network status (includes version info)
+ *   POST /upload            — upload a file (images, audio)
+ *   GET  /files/:name       — download uploaded file
  */
 
 const http = require('http');
@@ -27,13 +30,24 @@ const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
 
-const PORT = 8333; // mesh port
+const PORT = 8333;
 const DATA_DIR = path.join(__dirname, 'data');
 const NODES_FILE = path.join(DATA_DIR, 'nodes.json');
 const JOBS_FILE = path.join(DATA_DIR, 'jobs.json');
 const LEDGER_FILE = path.join(DATA_DIR, 'ledger.json');
 
-// Ensure data dir
+// Job TTLs — if claimed but not completed/failed within this time, auto-fail
+const JOB_CLAIM_TTL = {
+  ping: 30_000,
+  inference: 600_000,    // 10 min
+  transcribe: 900_000,   // 15 min
+  generate: 1_200_000,   // 20 min
+  default: 600_000       // 10 min
+};
+
+const REAPER_INTERVAL = 60_000; // Check for stale jobs every 60s
+const NODE_TIMEOUT = 180_000;   // 3 min without checkin = offline
+
 if (!fs.existsSync(DATA_DIR)) fs.mkdirSync(DATA_DIR, { recursive: true });
 
 // ===== STATE =====
@@ -54,41 +68,69 @@ function genId() {
   return crypto.randomBytes(8).toString('hex');
 }
 
-// ===== NODE REGISTRY =====
+// ===== NODE REGISTRY (with dedup) =====
+
+/**
+ * Find existing node by name+owner combo.
+ * This prevents duplicate registrations when a client restarts.
+ */
+function findNodeByIdentity(name, owner) {
+  for (const [id, node] of Object.entries(nodes)) {
+    if (node.name === name && node.owner === owner) {
+      return id;
+    }
+  }
+  return null;
+}
 
 function registerNode(data) {
-  const id = data.nodeId || genId();
   const now = Date.now();
-  
+
+  // Dedup: if client sends a nodeId, use it. Otherwise look up by name+owner.
+  let id = data.nodeId;
+  if (!id || !nodes[id]) {
+    // Client might have a stale ID or no ID — find by identity
+    const existingId = findNodeByIdentity(data.name, data.owner);
+    if (existingId) {
+      id = existingId;
+    } else {
+      id = genId();
+    }
+  }
+
+  const existing = nodes[id] || {};
+
   nodes[id] = {
     nodeId: id,
     name: data.name || 'unnamed',
     ip: data.ip || 'unknown',
-    capabilities: data.capabilities || [],  // ['ollama', 'whisper', 'gpu', 'ffmpeg']
-    models: data.models || [],              // ['llama3.1:8b', 'mistral:7b']
+    capabilities: data.capabilities || [],
+    models: data.models || [],
+    version: data.version || 'unknown',
     resources: {
       cpuCores: data.cpuCores || 0,
       ramMB: data.ramMB || 0,
       ramFreeMB: data.ramFreeMB || 0,
-      cpuIdle: data.cpuIdle || 0,           // percentage
+      cpuIdle: data.cpuIdle || 0,
       gpuVRAM: data.gpuVRAM || 0,
       diskFreeGB: data.diskFreeGB || 0
     },
     owner: data.owner || 'unknown',
     region: data.region || 'unknown',
     lastSeen: now,
-    registeredAt: nodes[id]?.registeredAt || now,
+    registeredAt: existing.registeredAt || now,
     status: 'online',
-    jobsCompleted: nodes[id]?.jobsCompleted || 0,
-    computeMinutes: nodes[id]?.computeMinutes || 0
+    jobsCompleted: existing.jobsCompleted || 0,
+    jobsFailed: existing.jobsFailed || 0,
+    computeMinutes: existing.computeMinutes || 0
   };
-  
+
   save(NODES_FILE, nodes);
   return nodes[id];
 }
 
 function getActiveNodes() {
-  const cutoff = Date.now() - 120000; // 2 min timeout
+  const cutoff = Date.now() - NODE_TIMEOUT;
   const active = {};
   for (const [id, node] of Object.entries(nodes)) {
     if (node.lastSeen > cutoff) {
@@ -105,23 +147,26 @@ function getActiveNodes() {
 function submitJob(data) {
   const id = genId();
   const now = Date.now();
-  
+
   jobs[id] = {
     jobId: id,
-    type: data.type,                        // 'inference', 'transcribe', 'generate', 'custom'
-    payload: data.payload || {},             // job-specific data
-    requester: data.requester,              // nodeId of requesting node
-    requirements: data.requirements || {},   // { capability: 'ollama', model: 'llama3.1:8b', minRAM: 8000 }
-    status: 'pending',                      // pending, claimed, running, completed, failed
+    type: data.type,
+    payload: data.payload || {},
+    requester: data.requester,
+    requirements: data.requirements || {},
+    status: 'pending',
     claimedBy: null,
     createdAt: now,
     claimedAt: null,
     completedAt: null,
     result: null,
-    computeMs: 0,                           // how long it took
-    creditAmount: 0                         // how much to credit the worker
+    error: null,
+    attempts: 0,
+    maxAttempts: data.maxAttempts || 2,
+    computeMs: 0,
+    creditAmount: 0
   };
-  
+
   save(JOBS_FILE, jobs);
   return jobs[id];
 }
@@ -129,30 +174,30 @@ function submitJob(data) {
 function getAvailableJobs(nodeId) {
   const available = [];
   const node = nodes[nodeId];
-  
+
   for (const [id, job] of Object.entries(jobs)) {
     if (job.status !== 'pending') continue;
-    
-    // Check if node meets requirements
+
     const req = job.requirements;
     if (req.capability && node && !node.capabilities.includes(req.capability)) continue;
     if (req.model && node && !node.models.includes(req.model)) continue;
     if (req.minRAM && node && node.resources.ramFreeMB < req.minRAM) continue;
-    
+
     available.push(job);
   }
-  
+
   return available;
 }
 
 function claimJob(jobId, nodeId) {
   const job = jobs[jobId];
   if (!job || job.status !== 'pending') return null;
-  
+
   job.status = 'claimed';
   job.claimedBy = nodeId;
   job.claimedAt = Date.now();
-  
+  job.attempts += 1;
+
   save(JOBS_FILE, jobs);
   return job;
 }
@@ -160,42 +205,91 @@ function claimJob(jobId, nodeId) {
 function completeJob(jobId, nodeId, result) {
   const job = jobs[jobId];
   if (!job || job.claimedBy !== nodeId) return null;
-  
+
   const now = Date.now();
   job.status = 'completed';
   job.completedAt = now;
   job.result = result.data || null;
   job.computeMs = now - job.claimedAt;
-  
-  // Calculate credits (1 credit = 1 minute of compute)
+
   const computeMinutes = job.computeMs / 60000;
   job.creditAmount = computeMinutes;
-  
-  // Update ledger
+
   if (!ledger[nodeId]) ledger[nodeId] = { earned: 0, spent: 0, jobs: 0 };
   if (!ledger[job.requester]) ledger[job.requester] = { earned: 0, spent: 0, jobs: 0 };
-  
-  const networkCut = computeMinutes * 0.20; // 20% to IC
+
+  const networkCut = computeMinutes * 0.20;
   const workerPay = computeMinutes - networkCut;
-  
+
   ledger[nodeId].earned += workerPay;
   ledger[nodeId].jobs += 1;
   ledger[job.requester].spent += computeMinutes;
-  
+
   if (!ledger['ic-treasury']) ledger['ic-treasury'] = { earned: 0, spent: 0, jobs: 0 };
   ledger['ic-treasury'].earned += networkCut;
-  
-  // Update node stats
+
   if (nodes[nodeId]) {
     nodes[nodeId].jobsCompleted = (nodes[nodeId].jobsCompleted || 0) + 1;
     nodes[nodeId].computeMinutes = (nodes[nodeId].computeMinutes || 0) + computeMinutes;
   }
-  
+
   save(JOBS_FILE, jobs);
   save(LEDGER_FILE, ledger);
   save(NODES_FILE, nodes);
-  
+
   return job;
+}
+
+function failJob(jobId, nodeId, error) {
+  const job = jobs[jobId];
+  if (!job) return null;
+  // Allow fail from the claiming node or from the reaper (nodeId=null)
+  if (nodeId && job.claimedBy !== nodeId) return null;
+
+  const now = Date.now();
+
+  // Track failure on node
+  if (job.claimedBy && nodes[job.claimedBy]) {
+    nodes[job.claimedBy].jobsFailed = (nodes[job.claimedBy].jobsFailed || 0) + 1;
+    save(NODES_FILE, nodes);
+  }
+
+  // If retries remain, re-queue. Otherwise mark failed.
+  if (job.attempts < job.maxAttempts) {
+    job.status = 'pending';
+    job.claimedBy = null;
+    job.claimedAt = null;
+    job.error = error || 'unknown';
+    console.log(`  ⟳ Job ${jobId} re-queued (attempt ${job.attempts}/${job.maxAttempts}): ${error}`);
+  } else {
+    job.status = 'failed';
+    job.completedAt = now;
+    job.error = error || 'unknown';
+    console.log(`  ✗ Job ${jobId} permanently failed after ${job.attempts} attempts: ${error}`);
+  }
+
+  save(JOBS_FILE, jobs);
+  return job;
+}
+
+// ===== JOB REAPER =====
+
+function reapStaleJobs() {
+  const now = Date.now();
+  let reaped = 0;
+
+  for (const [id, job] of Object.entries(jobs)) {
+    if (job.status !== 'claimed') continue;
+
+    const ttl = JOB_CLAIM_TTL[job.type] || JOB_CLAIM_TTL.default;
+    if (now - job.claimedAt > ttl) {
+      console.log(`◉ Reaper: job ${id} (${job.type}) timed out after ${Math.round((now - job.claimedAt)/1000)}s`);
+      failJob(id, null, `Timed out (no completion after ${Math.round(ttl/1000)}s)`);
+      reaped++;
+    }
+  }
+
+  if (reaped > 0) console.log(`◉ Reaper: cleared ${reaped} stale job(s)`);
 }
 
 // ===== COMPUTE BROKER =====
@@ -204,26 +298,27 @@ function findBestNode(requirements) {
   const active = getActiveNodes();
   let bestNode = null;
   let bestScore = -1;
-  
+
   for (const [id, node] of Object.entries(active)) {
-    // Check hard requirements
     if (requirements.capability && !node.capabilities.includes(requirements.capability)) continue;
     if (requirements.model && !node.models.includes(requirements.model)) continue;
     if (requirements.minRAM && node.resources.ramFreeMB < requirements.minRAM) continue;
-    
-    // Score by: idle CPU (40%), free RAM (30%), jobs completed reliability (30%)
+
     const cpuScore = (node.resources.cpuIdle || 0) / 100;
     const ramScore = Math.min((node.resources.ramFreeMB || 0) / 16000, 1);
     const reliabilityScore = Math.min((node.jobsCompleted || 0) / 100, 1);
-    
-    const score = cpuScore * 0.4 + ramScore * 0.3 + reliabilityScore * 0.3;
-    
+    // Penalize nodes with high failure rates
+    const failRate = (node.jobsFailed || 0) / Math.max((node.jobsCompleted || 0) + (node.jobsFailed || 0), 1);
+    const failPenalty = 1 - failRate;
+
+    const score = (cpuScore * 0.35 + ramScore * 0.25 + reliabilityScore * 0.2 + failPenalty * 0.2);
+
     if (score > bestScore) {
       bestScore = score;
       bestNode = node;
     }
   }
-  
+
   return bestNode;
 }
 
@@ -250,12 +345,12 @@ const server = http.createServer(async (req, res) => {
   const url = new URL(req.url, `http://localhost:${PORT}`);
   const method = req.method;
   const pathname = url.pathname;
-  
+
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, X-Node-Id, X-Node-Secret');
   if (method === 'OPTIONS') { res.writeHead(204); return res.end(); }
-  
+
   try {
     // ---- File Upload ----
     if (method === 'POST' && pathname === '/upload') {
@@ -263,14 +358,12 @@ const server = http.createServer(async (req, res) => {
       req.on('data', c => { chunks.push(c); if (Buffer.concat(chunks).length > 50 * 1024 * 1024) req.destroy(); });
       req.on('end', () => {
         const body = Buffer.concat(chunks);
-        // Extract filename from multipart or generate one
         const bodyStr = body.toString('latin1');
         const filenameMatch = bodyStr.match(/filename="([^"]+)"/);
         const ext = filenameMatch ? path.extname(filenameMatch[1]) : '.bin';
         const id = crypto.randomBytes(8).toString('hex');
         const filename = `upload-${id}${ext}`;
-        
-        // Find the file data between boundaries
+
         const boundaryMatch = bodyStr.match(/^--(----[^\r\n]+)/);
         if (boundaryMatch) {
           const boundary = boundaryMatch[1];
@@ -293,7 +386,7 @@ const server = http.createServer(async (req, res) => {
 
     // ---- File Serving ----
     if (method === 'GET' && pathname.startsWith('/files/')) {
-      const filename = pathname.split('/').pop();
+      const filename = path.basename(pathname); // sanitize
       const filePath = path.join(DATA_DIR, 'uploads', filename);
       if (!fs.existsSync(filePath)) return json(res, { error: 'Not found' }, 404);
       const stat = fs.statSync(filePath);
@@ -313,30 +406,22 @@ const server = http.createServer(async (req, res) => {
       const node = registerNode(data);
       return json(res, { ok: true, node });
     }
-    
+
     if (method === 'GET' && pathname === '/nodes') {
       return json(res, { nodes: getActiveNodes(), total: Object.keys(getActiveNodes()).length });
     }
-    
+
     // ---- Job Queue ----
     if (method === 'POST' && pathname === '/jobs') {
       const data = await parseBody(req);
-      
-      // Auto-route: find best node if not specified
+
       if (!data.targetNode) {
         const best = findBestNode(data.requirements || {});
         if (best) data.suggestedNode = best.nodeId;
       }
-      
+
       const job = submitJob(data);
       return json(res, { ok: true, job });
-    }
-    
-    if (method === 'GET' && pathname.match(/^\/jobs\/[a-f0-9]+$/) && !pathname.includes('/available')) {
-      const jobId = pathname.split('/')[2];
-      const job = jobs[jobId];
-      if (!job) return json(res, { error: 'Job not found' }, 404);
-      return json(res, { job });
     }
 
     if (method === 'GET' && pathname === '/jobs/available') {
@@ -344,7 +429,14 @@ const server = http.createServer(async (req, res) => {
       const available = getAvailableJobs(nodeId);
       return json(res, { jobs: available, count: available.length });
     }
-    
+
+    if (method === 'GET' && pathname.match(/^\/jobs\/[a-f0-9]+$/)) {
+      const jobId = pathname.split('/')[2];
+      const job = jobs[jobId];
+      if (!job) return json(res, { error: 'Job not found' }, 404);
+      return json(res, { job });
+    }
+
     if (method === 'POST' && pathname.match(/^\/jobs\/[a-f0-9]+\/claim$/)) {
       const jobId = pathname.split('/')[2];
       const data = await parseBody(req);
@@ -352,7 +444,7 @@ const server = http.createServer(async (req, res) => {
       if (!job) return json(res, { error: 'Job not available' }, 409);
       return json(res, { ok: true, job });
     }
-    
+
     if (method === 'POST' && pathname.match(/^\/jobs\/[a-f0-9]+\/complete$/)) {
       const jobId = pathname.split('/')[2];
       const data = await parseBody(req);
@@ -360,43 +452,56 @@ const server = http.createServer(async (req, res) => {
       if (!job) return json(res, { error: 'Not your job' }, 403);
       return json(res, { ok: true, job });
     }
-    
+
+    if (method === 'POST' && pathname.match(/^\/jobs\/[a-f0-9]+\/fail$/)) {
+      const jobId = pathname.split('/')[2];
+      const data = await parseBody(req);
+      const job = failJob(jobId, data.nodeId, data.error || 'Client reported failure');
+      if (!job) return json(res, { error: 'Not your job' }, 403);
+      return json(res, { ok: true, job });
+    }
+
     // ---- Ledger ----
     if (method === 'GET' && pathname.match(/^\/ledger\/.+$/)) {
       const nodeId = pathname.split('/')[2];
       const entry = ledger[nodeId] || { earned: 0, spent: 0, jobs: 0 };
       return json(res, { nodeId, ...entry, balance: entry.earned - entry.spent });
     }
-    
+
     // ---- Network Status ----
     if (method === 'GET' && pathname === '/status') {
       const active = getActiveNodes();
       const activeCount = Object.keys(active).length;
       const totalJobs = Object.values(jobs).length;
       const completedJobs = Object.values(jobs).filter(j => j.status === 'completed').length;
+      const failedJobs = Object.values(jobs).filter(j => j.status === 'failed').length;
+      const pendingJobs = Object.values(jobs).filter(j => j.status === 'pending').length;
+      const claimedJobs = Object.values(jobs).filter(j => j.status === 'claimed').length;
       const totalComputeMin = Object.values(ledger).reduce((sum, l) => sum + (l.earned || 0), 0);
       const treasury = ledger['ic-treasury'] || { earned: 0 };
-      
-      // Aggregate capabilities
+
       const allCaps = new Set();
       const allModels = new Set();
+      const versions = {};
       let totalRAM = 0;
       let totalCores = 0;
-      
+
       for (const node of Object.values(active)) {
         (node.capabilities || []).forEach(c => allCaps.add(c));
         (node.models || []).forEach(m => allModels.add(m));
         totalRAM += node.resources?.ramMB || 0;
         totalCores += node.resources?.cpuCores || 0;
+        if (node.version) versions[node.name] = node.version;
       }
-      
+
       return json(res, {
         network: 'Intelligence Club Mesh',
-        version: '0.1.0',
+        version: '0.2.0',
         status: activeCount > 0 ? 'online' : 'no nodes',
         nodes: {
           active: activeCount,
-          total: Object.keys(nodes).length
+          total: Object.keys(nodes).length,
+          versions
         },
         compute: {
           totalCores,
@@ -407,7 +512,9 @@ const server = http.createServer(async (req, res) => {
         jobs: {
           total: totalJobs,
           completed: completedJobs,
-          pending: Object.values(jobs).filter(j => j.status === 'pending').length
+          failed: failedJobs,
+          pending: pendingJobs,
+          claimed: claimedJobs
         },
         economics: {
           totalComputeMinutes: Math.round(totalComputeMin * 100) / 100,
@@ -416,15 +523,15 @@ const server = http.createServer(async (req, res) => {
         uptime: process.uptime()
       });
     }
-    
+
     // ---- Dashboard ----
     if (method === 'GET' && pathname === '/') {
       res.writeHead(200, { 'Content-Type': 'text/html' });
       return res.end(getDashboardHTML());
     }
-    
+
     json(res, { error: 'not found' }, 404);
-    
+
   } catch (e) {
     console.error('Error:', e);
     json(res, { error: e.message }, 500);
@@ -434,7 +541,8 @@ const server = http.createServer(async (req, res) => {
 function getDashboardHTML() {
   const active = getActiveNodes();
   const activeCount = Object.keys(active).length;
-  
+  const failedJobs = Object.values(jobs).filter(j => j.status === 'failed').length;
+
   return `<!DOCTYPE html>
 <html><head>
 <meta charset="UTF-8">
@@ -444,13 +552,16 @@ function getDashboardHTML() {
   * { margin: 0; padding: 0; box-sizing: border-box; }
   body { background: #0a0e17; color: #c8d6e5; font-family: 'Courier New', monospace; padding: 2rem; }
   h1 { color: #2d86ff; font-size: 1.2rem; letter-spacing: 0.2em; margin-bottom: 2rem; font-weight: 400; }
-  .stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 1rem; margin-bottom: 2rem; }
+  .stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 1rem; margin-bottom: 2rem; }
   .stat { border: 1px solid rgba(45,134,255,0.2); padding: 1.5rem; text-align: center; }
   .stat .num { font-size: 2rem; color: #22c55e; display: block; }
+  .stat .num.warn { color: #f59e0b; }
+  .stat .num.bad { color: #ef4444; }
   .stat .label { font-size: 0.7rem; color: #6b7c93; letter-spacing: 0.1em; text-transform: uppercase; margin-top: 0.5rem; }
   .node { border: 1px solid rgba(45,134,255,0.15); padding: 1rem; margin-bottom: 0.5rem; }
-  .node .name { color: #e0e8f0; }
+  .node .name { color: #e0e8f0; font-weight: bold; }
   .node .info { color: #6b7c93; font-size: 0.8rem; margin-top: 0.5rem; }
+  .node .version { color: #4a5568; font-size: 0.75rem; }
   .online { color: #22c55e; }
   .offline { color: #ef4444; }
   h2 { color: #2d86ff; font-size: 0.9rem; letter-spacing: 0.15em; margin: 2rem 0 1rem; font-weight: 400; }
@@ -461,28 +572,39 @@ function getDashboardHTML() {
 <div class="stats">
   <div class="stat"><span class="num">${activeCount}</span><span class="label">Active Nodes</span></div>
   <div class="stat"><span class="num">${Object.keys(nodes).length}</span><span class="label">Total Registered</span></div>
-  <div class="stat"><span class="num">${Object.values(jobs).filter(j => j.status === 'completed').length}</span><span class="label">Jobs Completed</span></div>
+  <div class="stat"><span class="num">${Object.values(jobs).filter(j => j.status === 'completed').length}</span><span class="label">Jobs Done</span></div>
+  <div class="stat"><span class="num${failedJobs > 0 ? ' bad' : ''}">${failedJobs}</span><span class="label">Jobs Failed</span></div>
   <div class="stat"><span class="num">${Math.round((ledger['ic-treasury']?.earned || 0) * 100) / 100}</span><span class="label">Treasury (min)</span></div>
 </div>
 <h2>NODES</h2>
-${Object.values(nodes).map(n => `
+${Object.values(nodes).sort((a,b) => b.lastSeen - a.lastSeen).map(n => {
+  const isOnline = n.lastSeen > Date.now() - NODE_TIMEOUT;
+  return `
 <div class="node">
   <span class="name">${n.name}</span>
-  <span class="${n.lastSeen > Date.now() - 120000 ? 'online' : 'offline'}"> ◉ ${n.lastSeen > Date.now() - 120000 ? 'ONLINE' : 'OFFLINE'}</span>
+  <span class="${isOnline ? 'online' : 'offline'}"> ◉ ${isOnline ? 'ONLINE' : 'OFFLINE'}</span>
+  <span class="version">${n.version || ''}</span>
   <div class="info">
-    ${n.capabilities.join(', ')} | ${n.resources.cpuCores} cores | ${Math.round(n.resources.ramMB/1024)}GB RAM | 
-    ${n.jobsCompleted} jobs | ${Math.round(n.computeMinutes*100)/100} compute min |
-    Last seen: ${new Date(n.lastSeen).toLocaleString()}
+    ${(n.capabilities || []).join(', ')} | ${n.resources?.cpuCores || '?'} cores | ${Math.round((n.resources?.ramMB || 0)/1024)}GB RAM |
+    ${n.jobsCompleted || 0} done${n.jobsFailed ? ` / ${n.jobsFailed} failed` : ''} |
+    ${Math.round((n.computeMinutes || 0)*100)/100} compute min |
+    Last: ${new Date(n.lastSeen).toLocaleString()}
   </div>
-</div>`).join('') || '<div class="node"><span class="info">No nodes registered yet. Start a client to join the mesh.</span></div>'}
-<p class="refresh">Auto-refreshes every 30s · <a href="/status" style="color:#2d86ff">API Status</a></p>
+</div>`;
+}).join('') || '<div class="node"><span class="info">No nodes registered yet.</span></div>'}
+<p class="refresh">Auto-refreshes every 30s · <a href="/status" style="color:#2d86ff">API</a></p>
 <script>setTimeout(() => location.reload(), 30000);</script>
 </body></html>`;
 }
 
+// ===== Start =====
+
 server.listen(PORT, '0.0.0.0', () => {
-  console.log(`◉ IC Mesh server live on port ${PORT}`);
+  console.log(`◉ IC Mesh server v0.2.0 live on port ${PORT}`);
   console.log(`  Dashboard: http://localhost:${PORT}`);
-  console.log(`  Status:    http://localhost:${PORT}/status`);
   console.log(`  Nodes:     ${Object.keys(nodes).length} registered`);
+  console.log(`  Reaper:    every ${REAPER_INTERVAL/1000}s`);
 });
+
+// Start the job reaper
+setInterval(reapStaleJobs, REAPER_INTERVAL);


### PR DESCRIPTION
## Safety-first production hardening

**Problem:** Clients can't be SSH'd into in production. Zombie processes, duplicate node registrations, and manual updates don't scale.

### Client changes
- **Persistent node ID** — saved to `.node-id` file, no more duplicate registrations on restart
- **Hard timeouts on all jobs** — ping 5s, inference 5min, transcribe 10min, SD 15min. Uses `spawn` + process group kill so child processes can't outlive their timeout
- **One job at a time** — `jobRunning` guard prevents claiming while executing
- **Auto-updates** — `git fetch` every 5min, if behind → `git pull` → re-exec itself. Waits for active job to finish first
- **Graceful shutdown** — SIGINT/SIGTERM kills active child process and exits clean
- **Reports failures** — `POST /jobs/:id/fail` so server knows and can re-queue

### Server changes
- **Node dedup** — `findNodeByIdentity(name, owner)` merges registrations from the same machine
- **Job reaper** — every 60s, checks for claimed jobs past TTL, auto-fails them (with re-queue if attempts remain)
- **`POST /jobs/:id/fail`** — clients report failures, server re-queues up to `maxAttempts` (default 2)
- **Failure tracking** — `jobsFailed` per node, factored into routing score
- **Version tracking** — each node reports git hash, visible in `/status` and dashboard

### Design principle
No SSH access to nodes in production. Everything must self-heal: timeouts kill zombies, dedup prevents ghost nodes, auto-update keeps fleet current.